### PR TITLE
Change memory limit via environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM php:7.3.8-fpm-alpine3.10
 ENV PHP_OPCACHE_VALIDATE_TIMESTAMPS="0" \
     PHP_OPCACHE_MAX_ACCELERATED_FILES="10000" \
     PHP_OPCACHE_MEMORY_CONSUMPTION="192" \
-    PHP_OPCACHE_MAX_WASTED_PERCENTAGE="10"
+    PHP_OPCACHE_MAX_WASTED_PERCENTAGE="10" \
+    PHP_MEMORY_LIMIT="512M"
 
 RUN apk info \
     && echo @edge http://nl.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories \

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A highly opinionated docker image which aims to be perfectly suited to run our L
 
 Create a `Dockerfile` with the following contents (and adjust version tag):
 
-```
+```dockerfile
 FROM sourceboat/docker-laravel:x.x.x
 
 # install yarn dependencies
@@ -40,7 +40,7 @@ RUN yarn production
 
 Create a `docker-compose.yml` with the following contents:
 
-```
+```yml
 version: '3.7'
 services:
   app:
@@ -48,6 +48,7 @@ services:
     restart: unless-stopped
     environment:
       - PHP_OPCACHE_VALIDATE_TIMESTAMPS=1
+      - PHP_MEMORY_LIMIT=1G #Set this to your desired value. Default: 512M
     volumes:
       - ./:/opt/app:cached
     ports:

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ services:
     restart: unless-stopped
     environment:
       - PHP_OPCACHE_VALIDATE_TIMESTAMPS=1
-      - PHP_MEMORY_LIMIT=1G #Set this to your desired value. Default: 512M
+      - PHP_MEMORY_LIMIT=1G
     volumes:
       - ./:/opt/app:cached
     ports:

--- a/usr/local/etc/php/php.ini
+++ b/usr/local/etc/php/php.ini
@@ -6,7 +6,7 @@
 
 max_execution_time = 60
 max_input_time = 60
-memory_limit = 512M
+memory_limit = ${PHP_MEMORY_LIMIT}
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Error handling and logging ;


### PR DESCRIPTION
This pr enables users of this image to change the php memory limit via a environment variable.

* add possiblity to change php memory limit via env (`PHP_MEMORY_LIMIT`)
* update readme and add syntax highlighting to code snippets