### PR TITLE
remove mbstring extension installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,6 @@ RUN apk info \
         intl \
         opcache \
         pcntl \
-        mbstring \
         iconv \
     && pecl install \
         redis \


### PR DESCRIPTION
Removes `mbstring` from the list of installed extensions as it is already [installed and configured](https://stackoverflow.com/questions/59251008/docker-laravel-configure-error-package-requirements-oniguruma-were-not-m/59253249#59253249).

see also #7 
