### PR TITLE
fix startup-commands typo

### DIFF
--- a/home/app/entrypoint.sh
+++ b/home/app/entrypoint.sh
@@ -15,7 +15,7 @@ echo "create storage symlink..."
 su www-data -s /bin/sh -c "php artisan storage:link -q"
 
 # startup commands
-php /usr/local/bin/startup_commands.php | bash
+php /usr/local/bin/startup-commands.php | bash
 
 cd /opt/app
 


### PR DESCRIPTION
Fix Typo in `entrypoint.sh`