### PR TITLE
Fix Dockerfile entrypoint and change dir before run artisan in entrypoint.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -110,6 +110,6 @@ RUN find /home/app -name "run-*.sh" -exec chmod -v +x {} \;
 RUN chmod +x /home/app/entrypoint.sh
 
 # run the application
-ENTRYPOINT bash /home/app/entrypoint.sh
+ENTRYPOINT ["/home/app/entrypoint.sh"]
 CMD /home/app/run-prod.sh
 EXPOSE 8080

--- a/home/app/entrypoint.sh
+++ b/home/app/entrypoint.sh
@@ -19,5 +19,4 @@ su www-data -s /bin/sh -c "php artisan storage:link -q"
 # startup commands
 php /usr/local/bin/startup-commands.php | bash
 
-
 exec "$@"

--- a/home/app/entrypoint.sh
+++ b/home/app/entrypoint.sh
@@ -10,13 +10,14 @@ touch /opt/app/storage/logs/worker.log
 chown www-data:www-data -R /opt/app/storage
 chown www-data:www-data -R /opt/app/bootstrap/cache
 
+cd /opt/app
+
 # create storage symlink
 echo "create storage symlink..."
 su www-data -s /bin/sh -c "php artisan storage:link -q"
 
-# startup commands
-php /usr/local/bin/startup_commands.php | bash
+#  startup commands
+php /usr/local/bin/startup-commands.php | bash
 
-cd /opt/app
 
-"$@"
+exec "$@"


### PR DESCRIPTION
This fix the `Dockerfile` entrypoint in the docker file. Bash is not not needed and causes an error. Docker runs the entrypoint default with `sh -c`.

In the `entrypoint.sh` the `cd` command is needed to run first, before the artisan command runs.