### PR TITLE
Added php-fpm environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,11 @@ ENV PHP_OPCACHE_VALIDATE_TIMESTAMPS="0" \
     PHP_OPCACHE_MEMORY_CONSUMPTION="192" \
     PHP_OPCACHE_MAX_WASTED_PERCENTAGE="10" \
     PHP_MEMORY_LIMIT="512M" \
-    PHP_MAX_EXECUTION_TIME="60"
+    PHP_MAX_EXECUTION_TIME="60" \
+    PHP_FPM_MAX_CHILDREN="100" \
+    PHP_FPM_MAX_REQUESTS="1000" \
+    PHP_FPM_PM="ondemand" \
+    PHP_FPM_PROCESS_IDLE_TIMEOUT="10s"
 
 RUN apk info \
     && echo @edge http://nl.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories \

--- a/usr/local/etc/php-fpm.d/zz-fpm.conf
+++ b/usr/local/etc/php-fpm.d/zz-fpm.conf
@@ -1,6 +1,6 @@
 [www]
 ; Ondemand process manager
-pm = ondemand
+pm = ${PHP_FPM_PM}
 
 ; The number of child processes to be created when pm is set to 'static' and the
 ; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.
@@ -11,18 +11,18 @@ pm = ondemand
 ; forget to tweak pm.* to fit your needs.
 ; Note: Used when pm is set to 'static', 'dynamic' or 'ondemand'
 ; Note: This value is mandatory.
-pm.max_children = 100
+pm.max_children = ${PHP_FPM_MAX_CHILDREN}
 
 ; The number of seconds after which an idle process will be killed.
 ; Note: Used only when pm is set to 'ondemand'
 ; Default Value: 10s
-pm.process_idle_timeout = 10s;
+pm.process_idle_timeout = ${PHP_FPM_PROCESS_IDLE_TIMEOUT};
 
 ; The number of requests each child process should execute before respawning.
 ; This can be useful to work around memory leaks in 3rd party libraries. For
 ; endless request processing specify '0'. Equivalent to PHP_FCGI_MAX_REQUESTS.
 ; Default Value: 0
-pm.max_requests = 1000
+pm.max_requests = ${PHP_FPM_MAX_REQUESTS}
 
 ; Make sure the FPM workers can reach the environment variables for configuration
 clear_env = no


### PR DESCRIPTION
Added the following environment variables with their defaults:
```
PHP_FPM_MAX_CHILDREN=100
PHP_FPM_MAX_REQUESTS=1000
PHP_FPM_PM=ondemand
PHP_FPM_PROCESS_IDLE_TIMEOUT=10s
```