### PR TITLE
install npm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN apk info \
         bash \
         git \
         nodejs \
+        npm \
         composer \
         php7-tokenizer \
         php7-simplexml \


### PR DESCRIPTION
This installs `npm` and `npx` (which is required for version 6 of Laravel Mix).