### PR TITLE
Update docker-laravel to use PHP8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4.19-fpm-alpine
+FROM php:8.0.7-fpm-alpine
 
 ENV PHP_OPCACHE_VALIDATE_TIMESTAMPS="0" \
     PHP_OPCACHE_MAX_ACCELERATED_FILES="10000" \
@@ -36,12 +36,17 @@ RUN apk info \
         nodejs \
         npm \
         composer \
-        php7-tokenizer \
-        php7-simplexml \
-        php7-dom \
+        php8-tokenizer \
+        php8-simplexml \
+        php8-dom \
         mysql-client \
         mariadb-connector-c \
         yarn@edge \
+    && git clone https://github.com/Imagick/imagick \
+    && cd imagick \
+    && git checkout master && git pull \
+    && phpize && ./configure && make && make install \
+    && cd .. && rm -Rf imagick \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-install -j$(nproc) \
         gd \
@@ -55,11 +60,11 @@ RUN apk info \
         iconv \
     && pecl install \
         redis \
-        imagick \
     && docker-php-ext-enable \
         redis \
         imagick \
-    && apk del .build-deps
+    && apk del .build-deps \
+    && rm -rf /tmp/* /var/cache/apk/* 
 
 # fix iconv (see https://github.com/docker-library/php/issues/240#issuecomment-305038173)
 RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing/ gnu-libiconv

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,6 @@ RUN apk info \
         nginx \
         zlib-dev \
         icu-dev \
-        imagemagick \
-        imagemagick-dev \
         libzip-dev \
         libjpeg-turbo-dev \
         libpng-dev \
@@ -42,11 +40,6 @@ RUN apk info \
         mysql-client \
         mariadb-connector-c \
         yarn@edge \
-    && git clone https://github.com/Imagick/imagick \
-    && cd imagick \
-    && git checkout master && git pull \
-    && phpize && ./configure && make && make install \
-    && cd .. && rm -Rf imagick \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-install -j$(nproc) \
         gd \
@@ -62,7 +55,6 @@ RUN apk info \
         redis \
     && docker-php-ext-enable \
         redis \
-        imagick \
     && apk del .build-deps \
     && rm -rf /tmp/* /var/cache/apk/* 
 


### PR DESCRIPTION
* Make changes to installed packages to use their php8 versions
* use php8 base image
* remove imagick
* candidate for major release?
* supersedes #57 